### PR TITLE
feat: 兼容微信小程序 npm 构建及发布

### DIFF
--- a/.babel.config.js
+++ b/.babel.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  plugins: [
+    ['module-resolver', {
+      root: './',
+      alias: {
+        // 'crypto-js': ([, name]) => `./lib/crypto-js${name}`,
+        'crypto-js': './lib/crypto-js',
+      },
+    }],
+  ],
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib
 es
 dist
 coverage
+miniprogram_dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,63 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@ampproject/remapping": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@babel/cli": {
+      "version": "7.17.10",
+      "resolved": "https://registry.npmmirror.com/@babel/cli/-/cli-7.17.10.tgz",
+      "integrity": "sha512-OygVO1M2J4yPMNOW9pb+I6kFGpQK77HmG44Oz3hg8xQIl5L/2zq+ZohwAdSaqYgVwM0SfmPHZHphH4wR8qzVYw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.8",
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+        "chokidar": "^3.4.0",
+        "commander": "^4.0.1",
+        "convert-source-map": "^1.1.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.0.0",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmmirror.com/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmmirror.com/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmmirror.com/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmmirror.com/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npm.taobao.org/@babel/code-frame/download/@babel/code-frame-7.10.4.tgz?cache=0&sync_timestamp=1593522826253&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fcode-frame%2Fdownload%2F%40babel%2Fcode-frame-7.10.4.tgz",
@@ -20,148 +77,259 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmmirror.com/@babel/core/download/@babel/core-7.16.0.tgz?cache=0&sync_timestamp=1635560662864&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40babel%2Fcore%2Fdownload%2F%40babel%2Fcore-7.16.0.tgz",
-      "integrity": "sha1-xP9EBG9f4xBSXMnrTvUUfwxTdNQ=",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.18.2.tgz",
+      "integrity": "sha512-A8pri1YJiC5UnkdrWcmfZTJTV85b4UXTAfImGmCfYmax4TR9Cw8sDS0MOk++Gp2mE/BefVJ5nwy5yzqNJbP/DQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/generator": "^7.16.0",
-        "@babel/helper-compilation-targets": "^7.16.0",
-        "@babel/helper-module-transforms": "^7.16.0",
-        "@babel/helpers": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.0",
-        "@babel/types": "^7.16.0",
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.18.2",
+        "@babel/helper-compilation-targets": "^7.18.2",
+        "@babel/helper-module-transforms": "^7.18.0",
+        "@babel/helpers": "^7.18.2",
+        "@babel/parser": "^7.18.0",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.18.2",
+        "@babel/types": "^7.18.2",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
-        "semver": "^6.3.0",
-        "source-map": "^0.5.0"
+        "json5": "^2.2.1",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmmirror.com/@babel/code-frame/download/@babel/code-frame-7.16.0.tgz?cache=0&sync_timestamp=1635560663383&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40babel%2Fcode-frame%2Fdownload%2F%40babel%2Fcode-frame-7.16.0.tgz",
-          "integrity": "sha1-DfyAMJvuyEEeZecGRhxAiwu5tDE=",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmmirror.com/@babel/code-frame/-/code-frame-7.16.7.tgz",
+          "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.16.0"
+            "@babel/highlight": "^7.16.7"
           }
         },
+        "@babel/compat-data": {
+          "version": "7.17.10",
+          "resolved": "https://registry.npmmirror.com/@babel/compat-data/-/compat-data-7.17.10.tgz",
+          "integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==",
+          "dev": true
+        },
         "@babel/generator": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmmirror.com/@babel/generator/download/@babel/generator-7.16.0.tgz?cache=0&sync_timestamp=1635560663614&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40babel%2Fgenerator%2Fdownload%2F%40babel%2Fgenerator-7.16.0.tgz",
-          "integrity": "sha1-1A89HVB15i01ALzLZ/PaqKlSZbI=",
+          "version": "7.18.2",
+          "resolved": "https://registry.npmmirror.com/@babel/generator/-/generator-7.18.2.tgz",
+          "integrity": "sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.16.0",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
+            "@babel/types": "^7.18.2",
+            "@jridgewell/gen-mapping": "^0.3.0",
+            "jsesc": "^2.5.1"
+          }
+        },
+        "@babel/helper-compilation-targets": {
+          "version": "7.18.2",
+          "resolved": "https://registry.npmmirror.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.2.tgz",
+          "integrity": "sha512-s1jnPotJS9uQnzFtiZVBUxe67CuBa679oWFHpxYYnTpRL/1ffhyX44R9uYiXoa/pLXcY9H2moJta0iaanlk/rQ==",
+          "dev": true,
+          "requires": {
+            "@babel/compat-data": "^7.17.10",
+            "@babel/helper-validator-option": "^7.16.7",
+            "browserslist": "^4.20.2",
+            "semver": "^6.3.0"
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmmirror.com/@babel/helper-function-name/download/@babel/helper-function-name-7.16.0.tgz",
-          "integrity": "sha1-t90Hl9ALv+5PB+nE6lsOMMi7FIE=",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmmirror.com/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
+          "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
           "dev": true,
           "requires": {
-            "@babel/helper-get-function-arity": "^7.16.0",
-            "@babel/template": "^7.16.0",
-            "@babel/types": "^7.16.0"
+            "@babel/template": "^7.16.7",
+            "@babel/types": "^7.17.0"
           }
         },
-        "@babel/helper-get-function-arity": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmmirror.com/@babel/helper-get-function-arity/download/@babel/helper-get-function-arity-7.16.0.tgz",
-          "integrity": "sha1-AIjHSGspqctdlIsaHeRttm4InPo=",
+        "@babel/helper-hoist-variables": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmmirror.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+          "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.16.0"
+            "@babel/types": "^7.16.7"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmmirror.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+          "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.7"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.18.0",
+          "resolved": "https://registry.npmmirror.com/@babel/helper-module-transforms/-/helper-module-transforms-7.18.0.tgz",
+          "integrity": "sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-environment-visitor": "^7.16.7",
+            "@babel/helper-module-imports": "^7.16.7",
+            "@babel/helper-simple-access": "^7.17.7",
+            "@babel/helper-split-export-declaration": "^7.16.7",
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "@babel/template": "^7.16.7",
+            "@babel/traverse": "^7.18.0",
+            "@babel/types": "^7.18.0"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.18.2",
+          "resolved": "https://registry.npmmirror.com/@babel/helper-simple-access/-/helper-simple-access-7.18.2.tgz",
+          "integrity": "sha512-7LIrjYzndorDY88MycupkpQLKS1AFfsVRm2k/9PtKScSy5tZq0McZTj+DiMRynboZfIqOKvo03pmhTaUgiD6fQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.18.2"
           }
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmmirror.com/@babel/helper-split-export-declaration/download/@babel/helper-split-export-declaration-7.16.0.tgz",
-          "integrity": "sha1-KWcvQ2Y+k23zcKrrIr7ds7rsdDg=",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmmirror.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+          "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.16.0"
+            "@babel/types": "^7.16.7"
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmmirror.com/@babel/helper-validator-identifier/download/@babel/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha1-Ig35k7/pBKSmsCq08zhaXr9uI4k=",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmmirror.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
           "dev": true
         },
-        "@babel/highlight": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmmirror.com/@babel/highlight/download/@babel/highlight-7.16.0.tgz",
-          "integrity": "sha1-bOsysspLj182H7f9gh4/3fShclo=",
+        "@babel/helper-validator-option": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmmirror.com/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+          "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+          "dev": true
+        },
+        "@babel/helpers": {
+          "version": "7.18.2",
+          "resolved": "https://registry.npmmirror.com/@babel/helpers/-/helpers-7.18.2.tgz",
+          "integrity": "sha512-j+d+u5xT5utcQSzrh9p+PaJX94h++KN+ng9b9WEJq7pkUPAd61FGqhjuUEdfknb3E/uDBb7ruwEeKkIxNJPIrg==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.15.7",
+            "@babel/template": "^7.16.7",
+            "@babel/traverse": "^7.18.2",
+            "@babel/types": "^7.18.2"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.17.12",
+          "resolved": "https://registry.npmmirror.com/@babel/highlight/-/highlight-7.17.12.tgz",
+          "integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
         },
         "@babel/parser": {
-          "version": "7.16.4",
-          "resolved": "https://registry.npmmirror.com/@babel/parser/download/@babel/parser-7.16.4.tgz?cache=0&sync_timestamp=1637105418396&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40babel%2Fparser%2Fdownload%2F%40babel%2Fparser-7.16.4.tgz",
-          "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
+          "version": "7.18.4",
+          "resolved": "https://registry.npmmirror.com/@babel/parser/-/parser-7.18.4.tgz",
+          "integrity": "sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==",
           "dev": true
         },
         "@babel/template": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmmirror.com/@babel/template/download/@babel/template-7.16.0.tgz?cache=0&sync_timestamp=1635560664232&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40babel%2Ftemplate%2Fdownload%2F%40babel%2Ftemplate-7.16.0.tgz",
-          "integrity": "sha1-0Wo16/TNdOICCDNW+rId2JNj3dY=",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmmirror.com/@babel/template/-/template-7.16.7.tgz",
+          "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.16.0",
-            "@babel/parser": "^7.16.0",
-            "@babel/types": "^7.16.0"
+            "@babel/code-frame": "^7.16.7",
+            "@babel/parser": "^7.16.7",
+            "@babel/types": "^7.16.7"
           }
         },
         "@babel/traverse": {
-          "version": "7.16.3",
-          "resolved": "https://registry.npmmirror.com/@babel/traverse/download/@babel/traverse-7.16.3.tgz",
-          "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
+          "version": "7.18.2",
+          "resolved": "https://registry.npmmirror.com/@babel/traverse/-/traverse-7.18.2.tgz",
+          "integrity": "sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.16.0",
-            "@babel/generator": "^7.16.0",
-            "@babel/helper-function-name": "^7.16.0",
-            "@babel/helper-hoist-variables": "^7.16.0",
-            "@babel/helper-split-export-declaration": "^7.16.0",
-            "@babel/parser": "^7.16.3",
-            "@babel/types": "^7.16.0",
+            "@babel/code-frame": "^7.16.7",
+            "@babel/generator": "^7.18.2",
+            "@babel/helper-environment-visitor": "^7.18.2",
+            "@babel/helper-function-name": "^7.17.9",
+            "@babel/helper-hoist-variables": "^7.16.7",
+            "@babel/helper-split-export-declaration": "^7.16.7",
+            "@babel/parser": "^7.18.0",
+            "@babel/types": "^7.18.2",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
         },
         "@babel/types": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmmirror.com/@babel/types/download/@babel/types-7.16.0.tgz",
-          "integrity": "sha1-2zsxOAT5aq3Qt3bEgj4SetZyibo=",
+          "version": "7.18.4",
+          "resolved": "https://registry.npmmirror.com/@babel/types/-/types-7.18.4.tgz",
+          "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.15.7",
+            "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
           }
         },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmmirror.com/semver/download/semver-6.3.0.tgz",
-          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmmirror.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
+          "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/set-array": "^1.0.0",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        },
+        "browserslist": {
+          "version": "4.20.4",
+          "resolved": "https://registry.npmmirror.com/browserslist/-/browserslist-4.20.4.tgz",
+          "integrity": "sha512-ok1d+1WpnU24XYN7oC3QWgTyMhY/avPJ/r9T00xxvUOIparA/gc+UPUMaod3i+G6s+nI2nUb9xZ5k794uIwShw==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001349",
+            "electron-to-chromium": "^1.4.147",
+            "escalade": "^3.1.1",
+            "node-releases": "^2.0.5",
+            "picocolors": "^1.0.0"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001350",
+          "resolved": "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001350.tgz",
+          "integrity": "sha512-NZBql38Pzd+rAu5SPXv+qmTWGQuFsRiemHCJCAPvkoDxWV19/xqL2YHF32fDJ9SDLdLqfax8+S0CO3ncDCp9Iw==",
           "dev": true
         },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+        "electron-to-chromium": {
+          "version": "1.4.148",
+          "resolved": "https://registry.npmmirror.com/electron-to-chromium/-/electron-to-chromium-1.4.148.tgz",
+          "integrity": "sha512-8MJk1bcQUAYkuvCyWZxaldiwoDG0E0AMzBGA6cv3WfuvJySiPgfidEPBFCRRH3cZm6SVZwo/oRlK1ehi1QNEIQ==",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmmirror.com/json5/-/json5-2.2.1.tgz",
+          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmmirror.com/node-releases/-/node-releases-2.0.5.tgz",
+          "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmmirror.com/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -367,6 +535,12 @@
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "regexpu-core": "^4.7.1"
       }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz",
+      "integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==",
+      "dev": true
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.16.0",
@@ -3049,6 +3223,44 @@
         }
       }
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/set-array/-/set-array-1.1.1.tgz",
+      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
+      "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@lerna/filter-packages": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/@lerna/filter-packages/download/@lerna/filter-packages-4.0.0.tgz",
@@ -3192,6 +3404,13 @@
       "requires": {
         "npmlog": "^4.1.2"
       }
+    },
+    "@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8-no-fsevents.3",
+      "resolved": "https://registry.npmmirror.com/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "dev": true,
+      "optional": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4087,6 +4306,19 @@
         "@babel/types": "^7.3.3",
         "@types/babel__core": "^7.0.0",
         "@types/babel__traverse": "^7.0.6"
+      }
+    },
+    "babel-plugin-module-resolver": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz",
+      "integrity": "sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==",
+      "dev": true,
+      "requires": {
+        "find-babel-config": "^1.2.0",
+        "glob": "^7.1.6",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.0.0",
+        "resolve": "^1.13.1"
       }
     },
     "babel-plugin-react-require": {
@@ -6787,6 +7019,30 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "find-babel-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/find-babel-config/-/find-babel-config-1.2.0.tgz",
+      "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
+      "dev": true,
+      "requires": {
+        "json5": "^0.5.1",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmmirror.com/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+          "dev": true
+        }
+      }
+    },
     "find-cache-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmmirror.com/find-cache-dir/download/find-cache-dir-2.1.0.tgz",
@@ -6955,14 +7211,14 @@
       }
     },
     "fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmmirror.com/fs-extra/download/fs-extra-8.1.0.tgz",
-      "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       }
     },
     "fs-mkdirp-stream": {
@@ -6986,6 +7242,12 @@
           }
         }
       }
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -9170,12 +9432,13 @@
       }
     },
     "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/download/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
       }
     },
     "jsprim": {
@@ -9444,11 +9707,6 @@
       "resolved": "https://registry.npmmirror.com/lodash.uniq/download/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
-    },
-    "loglevel": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npm.taobao.org/loglevel/download/loglevel-1.7.1.tgz?cache=0&sync_timestamp=1606314029553&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Floglevel%2Fdownload%2Floglevel-1.7.1.tgz",
-      "integrity": "sha1-AF/eL15uRwaPk1/yhXPhJe9y8Zc="
     },
     "longest": {
       "version": "1.0.1",
@@ -10448,6 +10706,51 @@
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
+      }
+    },
+    "pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmmirror.com/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmmirror.com/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmmirror.com/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+          "dev": true
+        }
       }
     },
     "please-upgrade-node": {
@@ -11604,6 +11907,12 @@
       "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
       "dev": true
     },
+    "reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmmirror.com/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.18.1",
       "resolved": "https://registry.npm.taobao.org/resolve/download/resolve-1.18.1.tgz?cache=0&sync_timestamp=1603315970196&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fresolve%2Fdownload%2Fresolve-1.18.1.tgz",
@@ -11789,6 +12098,26 @@
             "pkg-dir": "^4.1.0"
           }
         },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
         "resolve": {
           "version": "1.17.0",
           "resolved": "https://registry.npmmirror.com/resolve/download/resolve-1.17.0.tgz",
@@ -11797,6 +12126,12 @@
           "requires": {
             "path-parse": "^1.0.6"
           }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmmirror.com/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
         }
       }
     },
@@ -13412,9 +13747,9 @@
       }
     },
     "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmmirror.com/universalify/download/universalify-0.1.2.tgz",
-      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
     },
     "unquote": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "lib",
     "es",
     "dist",
-    "types"
+    "types",
+    "miniprogram_dist"
   ],
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,16 @@
   "main": "./lib/index",
   "module": "./es/index",
   "browser": "./dist/index.umd.js",
+  "miniprogram": "miniprogram_dist",
   "typings": "./types/index.d.ts",
   "scripts": {
     "lint": "eslint src --ext js --fix",
     "test": "npm run build && jest",
     "test:coverage": "npm run build && npx jest --silent --ci --coverage --coverageReporters=\"text\" --coverageReporters=\"text-summary\"",
-    "build": "father-build",
+    "build": "npm run clean && father-build && npm run build:miniprogram",
+    "clean": "rm -rf dist es lib miniprogram_dist",
+    "copy": "node ./script/build_miniprogram.js",
+    "build:miniprogram": "npm run copy; babel --config-file ./.babel.config.js --out-dir miniprogram_dist lib",
     "anaysis": "node script/compress_anaysis.js",
     "anaysis:write": "node script/compress_anaysis.js -w"
   },
@@ -45,10 +49,14 @@
     "crypto-js": "3.1.2"
   },
   "devDependencies": {
+    "@babel/cli": "^7.17.10",
+    "@babel/core": "^7.18.2",
+    "babel-plugin-module-resolver": "^4.1.0",
     "eslint": "^7.13.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.22.1",
     "father-build": "^1.20.4",
+    "fs-extra": "^10.1.0",
     "husky": "^4.3.0",
     "jest": "^26.6.3"
   }

--- a/script/build_miniprogram.js
+++ b/script/build_miniprogram.js
@@ -3,8 +3,19 @@
  * 思路：
  * 1.使用之前的流程生成 CommonJS 格式的 lib 文件夹
  * 2.拷贝 lib 目录到 miniprogram_dist 目录
- * 3.借助 CopyWebpackPlugin 拷贝 crypto-js 依赖下的相关资源到 miniprogram_dist/crypto-js 目录下
- * 4.编写自定义 babel 插件，读取 miniprogram_dist/crypto.js 中 crypto-js 相关依赖的引入并修改为相对路径引入，完成后保存替换
+ * 3.拷贝 crypto-js 依赖下的相关资源到 miniprogram_dist/crypto-js 目录下
+ * 4.借助 babel-plugin-module-resolver 插件，读取 miniprogram_dist/crypto.js 中 crypto-js 相关依赖的引入并修改为相对路径引入，完成后保存替换
  */
 
-console.log('TODO:')
+const fse = require('fs-extra')
+const path = require('path')
+
+function copyCryptoJs(to) {
+  fse.copy(path.resolve('./node_modules/crypto-js'), to).then(() => {
+    console.log('copy crypto-js to miniprogram_dist success!')
+  }).catch((e) => {
+    throw e
+  })
+}
+
+copyCryptoJs(path.resolve('./miniprogram_dist/crypto-js'))


### PR DESCRIPTION
兼容微信小程序 npm 构建及发布，npm 包增加 miniprogram_dist 文件目录，在微信小程序环境下使用时只需执行 `构建 npm` 无需手动拷贝 `node_modules/crypto-js` 目录下文件到 `miniprogram_npm/crypto-js` 中
即修复了[这个问题](https://developers.weixin.qq.com/community/develop/doc/000e0aabea04c029a54da773d5c000?highLine=%2520%25E6%25B2%25A1%25E6%259C%2589%25E6%2589%25BE%25E5%2588%25B0%25E5%258F%25AF%25E4%25BB%25A5%25E6%259E%2584%25E5%25BB%25BA%25E7%259A%2584%2520NPM%2520%25E5%258C%2585%25EF%25BC%258C%25E8%25AF%25B7%25E7%25A1%25AE%25E8%25AE%25A4%25E9%259C%2580%25E8%25A6%2581%25E5%258F%2582%25E4%25B8%258E%25E6%259E%2584%25E5%25BB%25BA%25E7%259A%2584%2520npm%2520%25E9%2583%25BD%25E5%259C%25A8%2520%2560miniprogramRoot%2560%2520%25E7%259B%25AE%25E5%25BD%2595%25E5%2586%2585%25EF%25BC%258C%25E6%2588%2596%25E9%2585%258D%25E7%25BD%25AE%2520project.config.json%2520%25E7%259A%2584%2520packNpmManually%2520%25E5%2592%258C%2520packNpmRelationList%2520%25E8%25BF%259B%25E8%25A1%258C%25E6%259E%2584%25E5%25BB%25BA)